### PR TITLE
Set correct modification time on page copy

### DIFF
--- a/admin/transfer.php
+++ b/admin/transfer.php
@@ -138,7 +138,8 @@ class admin_plugin_taggingsync_transfer extends DokuWiki_Admin_Plugin
         if (!$this->hlp->filesEqual(wikiFN($pid), $pagePathClient)) {
             io_makeFileDir($pagePathClient);
             copy(wikiFN($pid), $pagePathClient);
-            touch(wikiFN($pid), $this->now);
+            $modTime = filemtime(wikiFN($pid));
+            touch($pagePathClient, $modTime);
 
             io_makeFileDir($metaPathClient);
             copy(metaFN($pid, '.meta'), $metaPathClient);


### PR DESCRIPTION
This PR updates the timestamp of the synced file in the client wiki instead of the primary one