### PR TITLE
Sync tagging db

### DIFF
--- a/admin/transfer.php
+++ b/admin/transfer.php
@@ -90,7 +90,23 @@ class admin_plugin_taggingsync_transfer extends DokuWiki_Admin_Plugin
             $this->transferSinglePage($pid, $clientDataDir, $INPUT->str('summary'));
         }
 
+        if ($this->getConf('sync_database')) {
+            $this->transferTaggingDatabase();
+        }
+
         msg($this->getLang('msg: transfer done'), 1);
+    }
+
+    /**
+     * Transfer the complete tagging database (overwrites the target)
+     */
+    protected function transferTaggingDatabase()
+    {
+        global $conf;
+        $filename = "tagging.sqlite3";
+        $source = fullpath($conf['metadir']) . "/" . $filename;
+        $dest = trim($this->getConf('client_wiki_directory')) . "/meta/$filename";
+        copy($source, $dest);
     }
 
     /**

--- a/conf/default.php
+++ b/conf/default.php
@@ -7,3 +7,4 @@
 
 $conf['client_wiki_directory'] = '';
 $conf['client_log_namespace']  = '';
+$conf['sync_database']  = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,4 +8,4 @@
 
 $meta['client_wiki_directory'] = ['string'];
 $meta['client_log_namespace']  = ['string'];
-
+$meta['sync_database']  = ['onoff', '_caution' => 'warning'];

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -8,4 +8,4 @@
 // keys need to match the config setting name
 $lang['client_wiki_directory'] = 'Server directory path to the client wiki\'s data directory.';
 $lang['client_log_namespace']  = 'Namespace in the client wiki where the logs should be written';
-
+$lang['sync_database']         = 'Transfer the whole tagging database';


### PR DESCRIPTION
Adds a configuration option to transfer the complete tagging database from primary to client wiki. The option is disabled by default.